### PR TITLE
fix OperatorCategories typo: always created root category

### DIFF
--- a/app/scripts/react/components/operator_categories/create.js.jsx.coffee
+++ b/app/scripts/react/components/operator_categories/create.js.jsx.coffee
@@ -18,7 +18,7 @@ window.OperatorCategories_Create = React.createClass
         `<OperatorCategories_CreateButton onClick = { this.handleStart } />`
       when STATE_INPUT
         `<OperatorCategories_CreateForm  onFinish = { this.handleFinish } 
-          parentCategoryId={ this.props.parentCategoryId } />`
+          parentCategory={ this.props.parentCategory } />`
       else
         console.error? "Unknown state: #{@state.currentState}"
 


### PR DESCRIPTION
Из-за опечатки при попытке создания категории или подкатегории (в любом списке) всегда создавалась корневая категория.
