### PR TITLE
fix jqueryui-bootstrap conflict: only use ui.sortable and its dependenci...

### DIFF
--- a/app/scripts/libs.coffee
+++ b/app/scripts/libs.coffee
@@ -3,7 +3,11 @@ window.jQuery = jQuery
 #require 'jquery/dist/jquery'
 require 'bootstrap-sass-official/assets/javascripts/bootstrap.js'
 require 'jquery.role/lib/role.js'
-require 'jquery-ui'
+
+require 'jquery-ui/ui/core.js'
+require 'jquery-ui/ui/widget.js'
+require 'jquery-ui/ui/mouse.js'
+require 'jquery-ui/ui/sortable.js'
 
 window._ = require 'lodash'
 require 'blueimp-file-upload/js/vendor/jquery.ui.widget.js'

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -48,11 +48,6 @@ gulp.task "scripts", ->
           exports: null
           depends:
             'jquery': '$'
-        'jquery-ui':
-          path: 'app/bower_components/jquery-ui/jquery-ui.js'
-          exports: null
-          depends:
-            'jquery': '$'
 
     ))
     .on("error", handleError)


### PR DESCRIPTION
Исправление конфликта jquery-ui и bootstrap (по tooltip).
Вместо всей jquery-ui подключаем только ui.sortable и его зависимости.
Зависимости подсмотрел на jquery-ui download builder (http://jqueryui.com/download/)
